### PR TITLE
Updated installation instructions and added them to github readme.md

### DIFF
--- a/Readme
+++ b/Readme
@@ -67,6 +67,11 @@ Installation
 		To install it, open the .dmg image and drag the fre:ac application to a location of your choice
 		like the desktop or the Applications folder. Then double click the application to start fre:ac.
 
+		Alternatively, users of the package manager MacPorts (www.macports.org) may install fre:ac using
+		the following command:
+
+			sudo port install freac
+
 	Linux:
 
 		fre:ac is available as a Snap, Flatpak or AppImage package.

--- a/Readme.de
+++ b/Readme.de
@@ -67,6 +67,10 @@ Installation
 		Um es zu installieren, öffnen Sie die .dmg-Datei und ziehen Sie die fre:ac Anwendung an einen Ort Ihrer Wahl,
 		z.B. den Desktop oder den Ordner Programme. Doppelklicken Sie anschließend die Anwendung, um fre:ac zu starten.
 
+		Alternativ können Nutzer des Paketmanagers MacPorts (www.macports.org) fre:ac auch mit folgendem Befehl installieren:
+		
+			sudo port install freac
+
 	Linux:
 
 		fre:ac steht als Snap-, Flatpak- oder AppImage-Paket bereit.

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,26 @@ fre:ac is a free and open source audio converter. It supports audio CD ripping a
 ## Download
 Pre-built packages for Windows, macOS, Linux and FreeBSD are available at [freac.org](https://freac.org/latest-release/).
 
+## Installation
+### Windows
+fre:ac is distributed in two variants, an .exe file containing a setup wizard or alternatively a .zip archive that contains just the application without an installer. If you downloaded the .exe installer, simply run it and the setup wizard will guide you through the installation process creating start menu icons that will run fre:ac. If you downloaded the .zip package, please extract/move the contents to a location of your choice and run freac.exe to start fre:ac.
+
+### macOS
+fre:ac is distributed as an Apple Disk Image (.dmg) file. To install it, open the .dmg image and drag the fre:ac application to a location of your choice like the desktop or the Applications folder. Then double click the application to start fre:ac.
+
+Alternatively, users of the package manager [MacPorts](http://www.macports.org) may install fre:ac using the following command:
+
+    sudo port install freac
+
+### Linux
+fre:ac is available as a Snap, Flatpak or AppImage package. The Snap and Flatpak versions can be found and installed from the respective app stores. Please note that these versions run in restriced environments and might offer limited functionality. The AppImage package must be marked as executable after downloading using the following command:
+
+    chmod a+x freac*.AppImage
+The AppImage can then be executed to start fre:ac.
+
+### FreeBSD
+fre:ac is distributed as a .tar.gz archive. Please extract the contents to a location of your choice and execute the freac binary to start fre:ac.
+
 ## Compiling
 fre:ac depends on the [BoCA audio component framework](https://github.com/enzo1982/boca/) and the [smooth Class Library](https://github.com/enzo1982/smooth/). Please build and install those first.
 


### PR DESCRIPTION
@enzo1982 As discussed, here my PR for updating the readmes with macports installation instructions.

I felt I had to add the whole installation section to readme.md, as just adding macports installation instructions to readme.md would be inconsistent. Hope thats ok. If you dont like that, I suggest we keep readme.md as it is and just change the plaintext readmes.