### PR TITLE
README: Add Windows package manager installation instructions for community maintained fre:ac packages 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,14 +26,13 @@ Pre-built packages for Windows, macOS, Linux and FreeBSD are available at [freac
 ### Windows
 fre:ac is distributed in two variants, an .exe file containing a setup wizard or alternatively a .zip archive that contains just the application without an installer. If you downloaded the .exe installer, simply run it and the setup wizard will guide you through the installation process creating start menu icons that will run fre:ac. If you downloaded the .zip package, please extract/move the contents to a location of your choice and run freac.exe to start fre:ac.
 
-Alternatively, users of the package manager [**Scoop**](https://scoop.sh) may install a community-maintained pacakge for fre:ac using the following command:
+Alternatively, fre:ac may be installed from the Microsoft Store under this link: [fre:ac on the Microsoft Store](https://apps.microsoft.com/store/detail/freac-free-audio-converter/9P1XD8ZQJ7JD)
 
-    scoop install freac
-    
-Users of the package manager [**chocolately**](https://chocolatey.org) may instead install fre:ac as packaged/maintained by @tunisiano187 using either of the following commands:
+As another alternative, users of Windows package managers may install community-maintained packages of fre:ac using the following commands:
 
-    choco install freac
-    choco install freac.portable
+- [Chocolatey](https://chocolatey.org): `choco install freac`
+- [Scoop](https://scoop.sh): `scoop install freac`
+- [Winget](https://winget.run): `winget install fre:ac`
     
 ### macOS
 fre:ac is distributed as an Apple Disk Image (.dmg) file. To install it, open the .dmg image and drag the fre:ac application to a location of your choice like the desktop or the Applications folder. Then double click the application to start fre:ac.

--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,15 @@ Pre-built packages for Windows, macOS, Linux and FreeBSD are available at [freac
 ### Windows
 fre:ac is distributed in two variants, an .exe file containing a setup wizard or alternatively a .zip archive that contains just the application without an installer. If you downloaded the .exe installer, simply run it and the setup wizard will guide you through the installation process creating start menu icons that will run fre:ac. If you downloaded the .zip package, please extract/move the contents to a location of your choice and run freac.exe to start fre:ac.
 
+Alternatively, users of the package manager [**Scoop**](https://scoop.sh) may install a community-maintained pacakge for fre:ac using the following command:
+
+    scoop install freac
+    
+Users of the package manager [**chocolately**](https://chocolatey.org) may instead install fre:ac as packaged/maintained by @tunisiano187 using either of the following commands:
+
+    choco install freac
+    choco install freac.portable
+    
 ### macOS
 fre:ac is distributed as an Apple Disk Image (.dmg) file. To install it, open the .dmg image and drag the fre:ac application to a location of your choice like the desktop or the Applications folder. Then double click the application to start fre:ac.
 


### PR DESCRIPTION
Hello @enzo1982 !

Thanks so much for this incredible project. 

I wish to offer the following convenience addition to the project README:

1. Instructions and attribution/recognition for the possibility of installing `freac` via new-fangled windows package managers

I have become increasingly aware of the transition amongst Windows users - like myself - to reaching for the current generation of robustly maintained package managers like `scoop`, `choco(latey)` and `winget` as the first step for installing software. As I went about installing `freac` I noticed the README had no cli installation instructions. I decided to query the 3 managers listed above and the first 2 had up-to-date packages available, including a "portable" variant via chocolatey.

I'm not sure how you feel about endorsing third-party packages for `freac`, and if you had any aversions. 

At least, if one of those potential aversions included version drift, I know that `scoop` has awesome auto-update functionality, via deterministic github release url pattern matching (assuming you keep the filenaming pattern the same going forward, I guess). 

Would love to know what you thought of the suggestion and my proposed changes