### PR TITLE
Fix license text with no official text for invariant sections

### DIFF
--- a/manual/cs/advanced.html
+++ b/manual/cs/advanced.html
@@ -46,8 +46,8 @@ Příručka pro kopírování audio-CD pomocí fre:ac - Pokročilí</p>
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/cs/beginner.html
+++ b/manual/cs/beginner.html
@@ -69,8 +69,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/cs/faq.html
+++ b/manual/cs/faq.html
@@ -56,8 +56,8 @@ Někdy, pokud je fre:ac instalován do adresáře Program Files, ukládá své k
 		Copyright &copy; 2007-2016 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/cs/howto.html
+++ b/manual/cs/howto.html
@@ -107,8 +107,8 @@ fre:ac - Příručka nastavení a speciálních vlastností</p>
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/de/beginner.html
+++ b/manual/de/beginner.html
@@ -93,8 +93,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/el/beginner.html
+++ b/manual/el/beginner.html
@@ -133,8 +133,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/en/beginner.html
+++ b/manual/en/beginner.html
@@ -100,8 +100,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/en/faq.html
+++ b/manual/en/faq.html
@@ -58,8 +58,8 @@
 		Copyright &copy; 2007-2016 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/en/howto.html
+++ b/manual/en/howto.html
@@ -491,8 +491,8 @@
 		Copyright &copy; 2007-2022 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/es/beginner.html
+++ b/manual/es/beginner.html
@@ -66,8 +66,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/es/faq.html
+++ b/manual/es/faq.html
@@ -52,8 +52,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/es/howto.html
+++ b/manual/es/howto.html
@@ -103,8 +103,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/eu/beginner.html
+++ b/manual/eu/beginner.html
@@ -101,8 +101,8 @@
 		Copyrighta &copy; 2007-2020 fre:ac egitasmoa<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/eu/faq.html
+++ b/manual/eu/faq.html
@@ -58,8 +58,8 @@
 		Copyrighta &copy; 2007-2016 fre:ac egitasmoa<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/eu/howto.html
+++ b/manual/eu/howto.html
@@ -121,8 +121,8 @@
 		Copyrighta &copy; 2007-2020 fre:ac egitasmoa<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index.html
+++ b/manual/index.html
@@ -78,8 +78,8 @@
 		Copyright &copy; 2007-2021 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_cs.html
+++ b/manual/index_cs.html
@@ -64,8 +64,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_de.html
+++ b/manual/index_de.html
@@ -67,8 +67,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_el.html
+++ b/manual/index_el.html
@@ -77,8 +77,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_en.html
+++ b/manual/index_en.html
@@ -70,8 +70,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_eo.html
+++ b/manual/index_eo.html
@@ -64,8 +64,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_es.html
+++ b/manual/index_es.html
@@ -63,8 +63,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_eu.html
+++ b/manual/index_eu.html
@@ -70,8 +70,8 @@
 		Copyrighta &copy; 2007-2014 fre:ac egitasmoa<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_it.html
+++ b/manual/index_it.html
@@ -69,8 +69,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_pt.html
+++ b/manual/index_pt.html
@@ -77,8 +77,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_pt_BR.html
+++ b/manual/index_pt_BR.html
@@ -63,8 +63,8 @@
 		Direitos autorais &copy; 2007-2021 projeto fre:ac<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_ru.html
+++ b/manual/index_ru.html
@@ -72,8 +72,8 @@
 		Copyright &copy; 2007-2010 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/index_sv.html
+++ b/manual/index_sv.html
@@ -71,8 +71,8 @@
 		Copyright &copy; 2007-2021 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/it/beginner.html
+++ b/manual/it/beginner.html
@@ -72,8 +72,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt/beginner.html
+++ b/manual/pt/beginner.html
@@ -108,8 +108,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt/faq.html
+++ b/manual/pt/faq.html
@@ -63,8 +63,8 @@
 		Copyright &copy; 2007-2016 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt/howto.html
+++ b/manual/pt/howto.html
@@ -140,8 +140,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt_BR/beginner.html
+++ b/manual/pt_BR/beginner.html
@@ -66,8 +66,8 @@
 		Direitos autorais &copy; 2007-2021 projeto fre:ac<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt_BR/faq.html
+++ b/manual/pt_BR/faq.html
@@ -52,8 +52,8 @@
 		Direitos autorais &copy; 2007-2021 projeto fre:ac<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/pt_BR/howto.html
+++ b/manual/pt_BR/howto.html
@@ -406,8 +406,8 @@
 		Direitos autorais &copy; 2007-2021 projeto fre:ac<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/ru/beginner.html
+++ b/manual/ru/beginner.html
@@ -87,8 +87,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/ru/faq.html
+++ b/manual/ru/faq.html
@@ -80,8 +80,8 @@
 		Copyright &copy; 2007-2016 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/ru/howto.html
+++ b/manual/ru/howto.html
@@ -477,8 +477,8 @@
 		Copyright &copy; 2007-2020 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/sv/beginner.html
+++ b/manual/sv/beginner.html
@@ -105,8 +105,8 @@
 		Copyright &copy; 2007-2021 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/sv/faq.html
+++ b/manual/sv/faq.html
@@ -58,8 +58,8 @@
 		Copyright &copy; 2007-2021 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>

--- a/manual/sv/howto.html
+++ b/manual/sv/howto.html
@@ -603,8 +603,8 @@
 		Copyright &copy; 2007-2021 the fre:ac project<br/><br/>
 		Permission is granted to copy, distribute and/or modify this document under the terms of
 		the GNU Free Documentation License, Version 1.1 or any later version published by the
-		Free Software Foundation; with the no Invariant Sections, with no Front-Cover Texts, and
-		with no Back-Cover Texts. A copy of the license is included in the section entitled
+		Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and
+		no Back-Cover Texts. A copy of the license is included in the section entitled
 		&quot;<a href="../gfdl.html">GNU Free Documentation License</a>&quot;.
 	      </p>
 	    </div>


### PR DESCRIPTION
The original text triggers a warning in Debian's Lint program "Lintian" of "license-problem-gfdl-non-official-text".  This PR fixes the text to use official text.  Tested with Lintian to be working.