### PR TITLE
Enable manual editing of the output directory field

### DIFF
--- a/src/gui/edit_folder.cpp
+++ b/src/gui/edit_folder.cpp
@@ -14,7 +14,6 @@
 
 freac::FolderEditBox::FolderEditBox(const Point &iPos, const Size &iSize, Int maxSize) : EditBox(iPos, iSize, maxSize)
 {
-	cursor->Deactivate();
 }
 
 Int freac::FolderEditBox::Paint(Int message)

--- a/src/gui/main_joblist.cpp
+++ b/src/gui/main_joblist.cpp
@@ -392,6 +392,7 @@ freac::LayerJoblist::LayerJoblist() : Layer("Joblist")
 	edb_outdir = new FolderEditBox(Point(0, 27), Size(0, 0), 1024);
 	edb_outdir->SetOrientation(OR_LOWERLEFT);
 	edb_outdir->onSelectEntry.Connect(&LayerJoblist::OnSelectFolder, this);
+	edb_outdir->onEnter.Connect(&LayerJoblist::OnSelectFolder, this);
 	list_outdir = new List();
 
 	UpdateOutputDir();


### PR DESCRIPTION
FolderEditBox deactivated its own cursor, so the output directory
field in the main window could only be set via the folder picker
dropdown, never typed into directly.

Reactivate the cursor and route Enter to the existing OnSelectFolder
handler, which already validates the path, offers to create it if
missing, and updates the recent folders list. Typed paths now get the
same handling as picked ones.

Closes #780